### PR TITLE
Fade objects that are behind other slicers or parallel to view direction

### DIFF
--- a/Engine/include/application_state.h
+++ b/Engine/include/application_state.h
@@ -113,7 +113,8 @@ struct Sphere
     :Scaling()
     ,SH0Threshold()
     ,IsNormalized()
-    ,Resolution(){};
+    ,Resolution()
+    ,FadeIfHidden(){};
 
     /// The scaling factor for the sphere glyphs.
     ApplicationParameter<float> Scaling;
@@ -127,6 +128,9 @@ struct Sphere
     /// Resolution of the sphere. The higher, the more
     /// detailed the representation.
     ApplicationParameter<int> Resolution;
+
+    /// Whether hidden glyphs should fade to black.
+    ApplicationParameter<bool> FadeIfHidden;
 };
 
 /// Struct containing global parameters for window and inputs.

--- a/Engine/include/sh_field.h
+++ b/Engine/include/sh_field.h
@@ -106,6 +106,7 @@ private:
         float SH0threshold;
         float Scaling;
         unsigned int NbCoeffs;
+        unsigned int FadeIfHidden;
     };
 
     /// Struct containing the voxel grid attributes for the GPU.
@@ -154,6 +155,8 @@ private:
     /// \param[in] previous Previous 0th SH threshold.
     /// \param[in] threshold New SH0 threshold.
     void SetSH0Threshold(float previous, float threshold);
+
+    void SetFadeIfHidden(bool previous, bool fadeEnabled);
 
     /// Generate a vertex buffer object for data.
     /// \param[in] data The data to send to the GPU.

--- a/Engine/include/sh_field.h
+++ b/Engine/include/sh_field.h
@@ -139,24 +139,27 @@ private:
     /// Set sphere scaling.
     /// \param[in] previous Previous scaling multiplier.
     /// \param[in] scaling New scaling.
-    void SetSphereScaling(float previous, float scaling);
+    void setSphereScaling(float previous, float scaling);
 
     /// Set the 3D slice index.
     /// \param[in] previous Previous slice index.
     /// \param[in] indices New slice index.
-    void SetSliceIndex(glm::vec3 previous, glm::vec3 indices);
+    void setSliceIndex(glm::vec3 previous, glm::vec3 indices);
 
     /// Toggle per-voxel SH normalization by maximum radius.
     /// \param[in] previous Previous value.
     /// \param[in] normalized True to normalize SH by maximum radius.
-    void SetNormalized(bool previous, bool normalized);
+    void setNormalized(bool previous, bool normalized);
 
     /// Set the threshold on 0th SH coefficient.
     /// \param[in] previous Previous 0th SH threshold.
     /// \param[in] threshold New SH0 threshold.
-    void SetSH0Threshold(float previous, float threshold);
+    void setSH0Threshold(float previous, float threshold);
 
-    void SetFadeIfHidden(bool previous, bool fadeEnabled);
+    /// Toggle fading of hidden objects.
+    /// \param[in] previous Previous value.
+    /// \param[in] fadeEnabled New value for fading behaviour.
+    void setFadeIfHidden(bool previous, bool fadeEnabled);
 
     /// Generate a vertex buffer object for data.
     /// \param[in] data The data to send to the GPU.

--- a/Engine/shaders/compute.glsl
+++ b/Engine/shaders/compute.glsl
@@ -128,28 +128,6 @@ uint convertIndex3DToVoxID(uint i, uint j, uint k)
     return k * gridDims.x * gridDims.y + j * gridDims.x + i;
 }
 
-uint convertInvocationIDToVoxID(uint invocationID)
-{
-    if(invocationID < gridDims.x * gridDims.y)
-    {
-        // XY-slice
-        const uint j = invocationID / gridDims.x;
-        const uint i = invocationID - j * gridDims.x;
-        return convertIndex3DToVoxID(i, j, sliceIndex.z);
-    }
-    if(invocationID < gridDims.x * gridDims.y + gridDims.y * gridDims.z)
-    {
-        // YZ-slice
-        const uint j = (invocationID - gridDims.x * gridDims.y) /gridDims.z;
-        const uint k = invocationID - gridDims.x * gridDims.y - j * gridDims.z;
-        return convertIndex3DToVoxID(sliceIndex.x, j, k);
-    }
-    // XZ-slice
-    const uint k = (invocationID - gridDims.x * gridDims.y - gridDims.y * gridDims.z) / gridDims.x;
-    const uint i = invocationID - gridDims.x * gridDims.y - gridDims.y * gridDims.z - k * gridDims.x;
-    return convertIndex3DToVoxID(i, sliceIndex.y, k);
-}
-
 bool belongsToXSlice(uint invocationID)
 {
     return invocationID >= gridDims.x * gridDims.y &&
@@ -164,6 +142,28 @@ bool belongsToYSlice(uint invocationID)
 bool belongsToZSlice(uint invocationID)
 {
     return invocationID < gridDims.x * gridDims.y;
+}
+
+uint convertInvocationIDToVoxID(uint invocationID)
+{
+    if(belongsToZSlice(invocationID))
+    {
+        // XY-slice
+        const uint j = invocationID / gridDims.x;
+        const uint i = invocationID - j * gridDims.x;
+        return convertIndex3DToVoxID(i, j, sliceIndex.z);
+    }
+    if(belongsToXSlice(invocationID))
+    {
+        // YZ-slice
+        const uint j = (invocationID - gridDims.x * gridDims.y) /gridDims.z;
+        const uint k = invocationID - gridDims.x * gridDims.y - j * gridDims.z;
+        return convertIndex3DToVoxID(sliceIndex.x, j, k);
+    }
+    // XZ-slice
+    const uint k = (invocationID - gridDims.x * gridDims.y - gridDims.y * gridDims.z) / gridDims.x;
+    const uint i = invocationID - gridDims.x * gridDims.y - gridDims.y * gridDims.z - k * gridDims.x;
+    return convertIndex3DToVoxID(i, sliceIndex.y, k);
 }
 
 void main()

--- a/Engine/shaders/triangle.frag
+++ b/Engine/shaders/triangle.frag
@@ -12,6 +12,18 @@ layout(std430, binding=8) buffer gridInfoBuffer
     ivec4 isSliceDirty;
 };
 
+layout(std430, binding=7) buffer sphereInfoBuffer
+{
+    uint nbVertices;
+    uint nbIndices;
+    uint isNormalized; // bool
+    uint maxOrder;
+    float sh0Threshold;
+    float scaling;
+    uint nbCoeffs;
+    uint fadeIfHidden; // bool
+};
+
 in vec4 world_frag_pos;
 in vec4 color;
 in vec4 world_normal;
@@ -143,7 +155,7 @@ void main()
     vec3 ambient = color.xyz * KA;
     vec3 specular = vec3(1.0, 1.0, 1.0) * dot(r, frag_to_eye) * KS;
 
-    vec3 outColor = (ambient + diffuse + specular) * GetFading();
+    vec3 outColor = (ambient + diffuse + specular) * (fadeIfHidden > 0 ? GetFading() : 1.0f);
     shaded_color = vec4(outColor, 1.0f);
 }
 

--- a/Engine/shaders/triangle.frag
+++ b/Engine/shaders/triangle.frag
@@ -1,32 +1,153 @@
 #version 460
-in vec4 v_wpos;
-in vec3 v_color;
-in vec4 v_normal;
-in vec4 v_weye;
-in float v_isVisible;
 
-out vec4 color;
+layout(std430, binding=10) buffer modelTransformsBuffer
+{
+    mat4 modelMatrix;
+};
+
+layout(std430, binding=8) buffer gridInfoBuffer
+{
+    ivec4 gridDims;
+    ivec4 sliceIndex;
+    ivec4 isSliceDirty;
+};
+
+in vec4 world_frag_pos;
+in vec4 color;
+in vec4 world_normal;
+in vec4 world_eye_pos;
+in vec4 vertex_slice;
+in float is_visible;
+
+out vec4 shaded_color;
+
+const vec4 X_SLICE_NORMAL = vec4(1.0f, 0.0f, 0.0f, 0.0f);
+const vec4 Y_SLICE_NORMAL = vec4(0.0f, 1.0f, 0.0f, 0.0f);
+const vec4 Z_SLICE_NORMAL = vec4(0.0f, 0.0f, 1.0f, 0.0f);
 
 const float KA = 0.3;
 const float KD = 0.6;
 const float KS = 0.1;
-const float IS_VISIBLE_EPSILON = 0.1f;
+
+const float PARALLEL_PLANE_EPSILON = 0.1f;
+const float HIDDEN_FRAG_TRANSITION_SIGMA = 0.1f;
+const float PARALLEL_FRAG_TRANSITION_SIGMA = 0.15f;
+const float MIN_ALPHA = 0.1f;
+
+float getNormalized(float x, float cmin, float cmax, float nmin, float nmax)
+{
+    return (x - cmin)/(cmax - cmin)*(nmax - nmin) + nmin;
+}
+
+float alphaTransitionFunction(float x, float sigma, float minFading)
+{
+    const float fx = exp(-0.5f * pow(x / sigma, 2));
+    return getNormalized(fx, 0.0f, 1.0f, minFading, 1.0f);
+}
+
+float GetFading()
+{
+    // world coordinate of planes intersection
+    const vec4 planesIntersection = modelMatrix
+                                  * vec4(float(sliceIndex.x - gridDims.x / 2),
+                                         float(sliceIndex.y - gridDims.y / 2),
+                                         float(sliceIndex.z - gridDims.z / 2),
+                                         1.0f);
+
+    const vec4 planesCenterToFragPosDir = normalize(world_frag_pos - planesIntersection);
+    const vec4 planesCenterToEyePosDir = normalize(world_eye_pos - planesIntersection);
+
+    // slices normal
+    vec4 worldXNormal = normalize(modelMatrix * X_SLICE_NORMAL);
+    vec4 worldYNormal = normalize(modelMatrix * Y_SLICE_NORMAL);
+    vec4 worldZNormal = normalize(modelMatrix * Z_SLICE_NORMAL);
+    worldXNormal = faceforward(worldXNormal, -worldXNormal, planesCenterToEyePosDir);
+    worldYNormal = faceforward(worldYNormal, -worldYNormal, planesCenterToEyePosDir);
+    worldZNormal = faceforward(worldZNormal, -worldZNormal, planesCenterToEyePosDir);
+
+    const vec3 absDotEyeNormal = vec3(abs(dot(planesCenterToEyePosDir, worldXNormal)),
+                                      abs(dot(planesCenterToEyePosDir, worldYNormal)),
+                                      abs(dot(planesCenterToEyePosDir, worldZNormal)));
+    const bvec3 isBehindSlice = bvec3(dot(planesCenterToFragPosDir, worldXNormal) < 0.0f &&
+                                      absDotEyeNormal.x > PARALLEL_PLANE_EPSILON &&
+                                      vertex_slice.x < 0.0f,
+                                      dot(planesCenterToFragPosDir, worldYNormal) < 0.0f &&
+                                      absDotEyeNormal.y > PARALLEL_PLANE_EPSILON &&
+                                      vertex_slice.y < 0.0f,
+                                      dot(planesCenterToFragPosDir, worldZNormal) < 0.0f &&
+                                      absDotEyeNormal.z > PARALLEL_PLANE_EPSILON &&
+                                      vertex_slice.z < 0.0f);
+
+    // test for fragment behind planes
+    float fading = 1.0f;
+    if(isBehindSlice.x)
+    {
+        // object is behind X plane and does not belong to X plane
+        const float x = getNormalized(absDotEyeNormal.x, MIN_ALPHA, 1.0f, 0.0f, 1.0f);
+        fading = min(fading, alphaTransitionFunction(x, HIDDEN_FRAG_TRANSITION_SIGMA, MIN_ALPHA));
+    }
+    if(isBehindSlice.y)
+    {
+        // object is behind Y plane and does not belong to Y plane
+        const float x = getNormalized(absDotEyeNormal.y, MIN_ALPHA, 1.0f, 0.0f, 1.0f);
+        fading = min(fading, alphaTransitionFunction(x, HIDDEN_FRAG_TRANSITION_SIGMA, MIN_ALPHA));
+    }
+    if(isBehindSlice.z)
+    {
+        // object is behind Z plane and does not belong to Z plane
+        const float x = getNormalized(absDotEyeNormal.z, MIN_ALPHA, 1.0f, 0.0f, 1.0f);
+        fading = min(fading, alphaTransitionFunction(x, HIDDEN_FRAG_TRANSITION_SIGMA, MIN_ALPHA));
+    }
+
+    // the fragment is not blocked by any plane; is it parallel?
+    if(vertex_slice.x > 0.0f && vertex_slice.y < 0.0f && vertex_slice.z < 0.0f)
+    {
+        if(absDotEyeNormal.x < PARALLEL_PLANE_EPSILON / 2.0f)
+        {
+            discard;
+        }
+        fading = min(fading, 1.0f + MIN_ALPHA - alphaTransitionFunction(absDotEyeNormal.x, PARALLEL_FRAG_TRANSITION_SIGMA, 0.0f));
+    }
+    if(vertex_slice.x < 0.0f && vertex_slice.y > 0.0f && vertex_slice.z < 0.0f)
+    {
+        if(absDotEyeNormal.y < PARALLEL_PLANE_EPSILON / 2.0f)
+        {
+            discard;
+        }
+        fading = min(fading, 1.0f + MIN_ALPHA - alphaTransitionFunction(absDotEyeNormal.y, PARALLEL_FRAG_TRANSITION_SIGMA, 0.0f));
+    }
+    if(vertex_slice.x < 0.0f && vertex_slice.y < 0.0f && vertex_slice.z > 0.0f)
+    {
+        if(absDotEyeNormal.z < PARALLEL_PLANE_EPSILON / 2.0f)
+        {
+            discard;
+        }
+        fading = min(fading, 1.0f + MIN_ALPHA - alphaTransitionFunction(absDotEyeNormal.z, PARALLEL_FRAG_TRANSITION_SIGMA, 0.0f));
+    }
+
+    // the fragment is not behind any plane
+    return fading;
+}
 
 void main()
 {
-    if(v_isVisible < 1.0f - IS_VISIBLE_EPSILON)
+    if(is_visible < 0.0f)
     {
         discard;
     }
 
-    vec3 n = normalize(v_normal.xyz);
-    vec3 eye = normalize(v_weye.xyz - v_wpos.xyz);
-    vec3 light = eye;
-    vec3 r = 2.0f * dot(light, n) * n - light;
-    vec3 diffuse = v_color * abs(dot(n, eye.xyz)) * KD;
-    vec3 ambient = v_color * KA;
-    vec3 specular = vec3(1.0, 1.0, 1.0) * dot(r, eye) * KS;
+    vec3 n = normalize(world_normal.xyz);
+    vec3 frag_to_eye = normalize(world_eye_pos.xyz - world_frag_pos.xyz);
+    vec3 frag_to_light = frag_to_eye;
+    vec3 r = 2.0f * dot(frag_to_light, n) * n - frag_to_light;
+    vec3 diffuse = color.xyz * abs(dot(n, frag_to_eye.xyz)) * KD;
+    vec3 ambient = color.xyz * KA;
+    vec3 specular = vec3(1.0, 1.0, 1.0) * dot(r, frag_to_eye) * KS;
 
-    vec3 outColor = ambient + diffuse + specular;
-    color = vec4(outColor, 1.0f);
+    vec3 outColor = (ambient + diffuse + specular) * GetFading();
+    shaded_color = vec4(outColor, 1.0f);
 }
+
+    //const float x = length(world_pos.xyz - planesIntersection.xyz);
+    //const float sigma = 15.0f;
+    //const float fading = pow(EULERS_NUMBER, -0.5f * pow(x / sigma, 2.0f));

--- a/Engine/shaders/triangle.frag
+++ b/Engine/shaders/triangle.frag
@@ -158,7 +158,3 @@ void main()
     vec3 outColor = (ambient + diffuse + specular) * (fadeIfHidden > 0 ? GetFading() : 1.0f);
     shaded_color = vec4(outColor, 1.0f);
 }
-
-    //const float x = length(world_pos.xyz - planesIntersection.xyz);
-    //const float sigma = 15.0f;
-    //const float fading = pow(EULERS_NUMBER, -0.5f * pow(x / sigma, 2.0f));

--- a/Engine/shaders/triangle.frag
+++ b/Engine/shaders/triangle.frag
@@ -81,21 +81,21 @@ float GetFading()
     if(isBehindSlice.x)
     {
         // object is behind X plane and does not belong to X plane
-        const float x = getNormalized(absDotEyeNormal.x, MIN_ALPHA, 1.0f, 0.0f, 1.0f);
+        const float x = getNormalized(absDotEyeNormal.x, MIN_BG_SHADING, 1.0f, 0.0f, 1.0f);
         backgroundFading = min(backgroundFading,
                                transitionFunction(x, HIDDEN_FRAG_SIGMA, MIN_BG_SHADING));
     }
     if(isBehindSlice.y)
     {
         // object is behind Y plane and does not belong to Y plane
-        const float x = getNormalized(absDotEyeNormal.y, MIN_ALPHA, 1.0f, 0.0f, 1.0f);
+        const float x = getNormalized(absDotEyeNormal.y, MIN_BG_SHADING, 1.0f, 0.0f, 1.0f);
         backgroundFading = min(backgroundFading,
                                transitionFunction(x, HIDDEN_FRAG_SIGMA, MIN_BG_SHADING));
     }
     if(isBehindSlice.z)
     {
         // object is behind Z plane and does not belong to Z plane
-        const float x = getNormalized(absDotEyeNormal.z, MIN_ALPHA, 1.0f, 0.0f, 1.0f);
+        const float x = getNormalized(absDotEyeNormal.z, MIN_BG_SHADING, 1.0f, 0.0f, 1.0f);
         backgroundFading = min(backgroundFading,
                                transitionFunction(x, HIDDEN_FRAG_SIGMA, MIN_BG_SHADING));
     }

--- a/Engine/shaders/triangle.frag
+++ b/Engine/shaders/triangle.frag
@@ -45,7 +45,7 @@ const float PARALLEL_PLANE_EPSILON = 0.1f;
 const float HIDDEN_FRAG_SIGMA = 0.1f;
 const float PARALLEL_FRAG_SIGMA = 0.12f;
 const float MIN_BG_SHADING = 0.2f;
-const float MIN_ALPHA = 0.1f;
+const float MIN_SHADING_THRESHOLD = 0.1f;
 
 float getNormalized(float x, float cmin, float cmax, float nmin, float nmax)
 {
@@ -132,7 +132,7 @@ float GetFading()
     }
 
     const float fading = min(backgroundFading, parallelPlanesFading);
-    if(fading < MIN_ALPHA)
+    if(fading < MIN_SHADING_THRESHOLD)
     {
         discard;
     }

--- a/Engine/shaders/triangle.vert
+++ b/Engine/shaders/triangle.vert
@@ -54,22 +54,41 @@ layout(std430, binding=10) buffer modelTransformsBuffer
 out gl_PerVertex{
     vec4 gl_Position;
 };
-out vec4 v_wpos;
-out vec3 v_color;
-out vec4 v_normal;
-out vec4 v_weye;
-out float v_isVisible;
+out vec4 world_frag_pos;
+out vec4 color;
+out vec4 world_normal;
+out vec4 world_eye_pos;
+
+// Identify the slice a vertex belongs to.
+// -1 if the vertex does not belong to slice at index;
+// +1 if the vertex belongs to the slice at index.
+out vec4 vertex_slice;
+
+// An object is not visible if its SH0 coefficient
+// is below the threshold.
+out float is_visible;
+
+bool belongsToXSlice(uint invocationID)
+{
+    return invocationID >= gridDims.x * gridDims.y &&
+           invocationID < gridDims.x * gridDims.y + gridDims.y * gridDims.z;
+}
+
+bool belongsToZSlice(uint invocationID)
+{
+    return invocationID < gridDims.x * gridDims.y;
+}
 
 ivec3 convertInvocationIDToIndex3D(uint invocationID)
 {
-    if(invocationID < gridDims.x * gridDims.y)
+    if(belongsToZSlice(invocationID))
     {
         // XY-slice
         const uint j = invocationID / gridDims.x;
         const uint i = invocationID - j * gridDims.x;
         return ivec3(i, j, sliceIndex.z);
     }
-    if(invocationID < gridDims.x * gridDims.y + gridDims.y * gridDims.z)
+    if(belongsToXSlice(invocationID))
     {
         // YZ-slice
         const uint j = (invocationID - gridDims.x * gridDims.y) /gridDims.z;
@@ -85,6 +104,15 @@ ivec3 convertInvocationIDToIndex3D(uint invocationID)
 uint convertIndex3DToVoxID(uint i, uint j, uint k)
 {
     return k * gridDims.x * gridDims.y + j * gridDims.x + i;
+}
+
+vec4 GetVertexSlice(ivec3 index3d)
+{
+    const float i = index3d.x == sliceIndex.x ? 1.0f : -1.0f;
+    const float j = index3d.y == sliceIndex.y ? 1.0f : -1.0f;
+    const float k = index3d.z == sliceIndex.z ? 1.0f : -1.0f;
+
+    return vec4(i, j, k, 0.0f);
 }
 
 void main()
@@ -110,13 +138,14 @@ void main()
                 * localMatrix
                 * currentVertex;
 
-    v_wpos = modelMatrix
-           * localMatrix
-           * currentVertex;
+    world_frag_pos = modelMatrix
+                   * localMatrix
+                   * currentVertex;
 
-    v_normal = modelMatrix
-             * allNormals[gl_VertexID];
-    v_color = abs(normalize(currentVertex.xyz));
-    v_isVisible = isVisible ? 1.0f:0.0f;
-    v_weye = eye;
+    world_normal = modelMatrix
+                 * allNormals[gl_VertexID];
+    color = abs(vec4(normalize(currentVertex.xyz), 1.0f));
+    is_visible = isVisible ? 1.0f : -1.0f;
+    world_eye_pos = vec4(eye.xyz, 1.0f);
+    vertex_slice = GetVertexSlice(index3d);
 }

--- a/Engine/shaders/triangle.vert
+++ b/Engine/shaders/triangle.vert
@@ -29,6 +29,7 @@ layout(std430, binding=7) buffer sphereInfoBuffer
     float sh0Threshold;
     float scaling;
     uint nbCoeffs;
+    uint fadeIfHidden; // bool
 };
 
 layout(std430, binding=8) buffer gridInfoBuffer

--- a/Engine/src/application.cpp
+++ b/Engine/src/application.cpp
@@ -71,6 +71,8 @@ void Application::initialize()
     glEnable(GL_DEPTH_TEST);
     glEnable(GL_CULL_FACE);
     glCullFace(GL_BACK);
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     glfwSwapInterval(0);
 
     mUI.reset(new UIManager(mWindow, GLSL_VERSION_STR, mState));

--- a/Engine/src/application.cpp
+++ b/Engine/src/application.cpp
@@ -71,8 +71,6 @@ void Application::initialize()
     glEnable(GL_DEPTH_TEST);
     glEnable(GL_CULL_FACE);
     glCullFace(GL_BACK);
-    glEnable(GL_BLEND);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     glfwSwapInterval(0);
 
     mUI.reset(new UIManager(mWindow, GLSL_VERSION_STR, mState));

--- a/Engine/src/application.cpp
+++ b/Engine/src/application.cpp
@@ -95,6 +95,7 @@ void Application::initApplicationState(const ArgumentParser& parser)
     mState->Sphere.IsNormalized.Update(false);
     mState->Sphere.Scaling.Update(0.5f);
     mState->Sphere.SH0Threshold.Update(0.0f);
+    mState->Sphere.FadeIfHidden.Update(true);
 
     mState->VoxelGrid.VolumeShape.Update(mState->FODFImage.Get().dims());
     mState->VoxelGrid.SliceIndices.Update(mState->VoxelGrid.VolumeShape.Get() / 2);

--- a/Engine/src/gui.cpp
+++ b/Engine/src/gui.cpp
@@ -86,7 +86,7 @@ void UIManager::drawPreferencesWindow()
         return;
     
     ImGui::SetNextWindowPos(ImVec2(5.f, 25.f), ImGuiCond_FirstUseEver);
-    ImGui::SetNextWindowSize(ImVec2(406.f, 79.f), ImGuiCond_FirstUseEver);
+    ImGui::SetNextWindowSize(ImVec2(406.f, 108.f), ImGuiCond_FirstUseEver);
     ImGui::SetNextWindowCollapsed(false, ImGuiCond_FirstUseEver);
 
     ImGui::Begin("Preferences", &mShowPreferences);
@@ -122,7 +122,7 @@ void UIManager::drawSlicersWindow()
         return;
 
     ImGui::SetNextWindowPos(ImVec2(5.f, 25.f), ImGuiCond_FirstUseEver);
-    ImGui::SetNextWindowSize(ImVec2(417.f, 180.f), ImGuiCond_FirstUseEver);
+    ImGui::SetNextWindowSize(ImVec2(417.f, 200.f), ImGuiCond_FirstUseEver);
     ImGui::SetNextWindowCollapsed(false, ImGuiCond_FirstUseEver);
 
     ImGui::Begin("Slices options", &mShowSlicers);
@@ -188,7 +188,9 @@ void UIManager::drawSlicersWindow()
     auto& scalingParam = mState->Sphere.Scaling;
     auto& thresholdParam = mState->Sphere.SH0Threshold;
     auto& normalizedParam = mState->Sphere.IsNormalized;
-    if (!scalingParam.IsInit() || !thresholdParam.IsInit() || !normalizedParam.IsInit())
+    auto& fadeHiddenParam = mState->Sphere.FadeIfHidden;
+    if (!scalingParam.IsInit() || !thresholdParam.IsInit() ||
+        !normalizedParam.IsInit() || !fadeHiddenParam.IsInit())
     {
         ImGui::Spacing();
         ImGui::End();
@@ -198,6 +200,7 @@ void UIManager::drawSlicersWindow()
     float scaling = scalingParam.Get();
     float threshold = thresholdParam.Get();
     bool normalized = normalizedParam.Get();
+    bool fadeIfHidden = fadeHiddenParam.Get();
 
     ImGui::Text("Sphere scaling");
     ImGui::SameLine();
@@ -216,6 +219,12 @@ void UIManager::drawSlicersWindow()
     if(ImGui::Checkbox("##sphere.normalized", &normalized))
     {
         normalizedParam.Update(normalized);
+    }
+    ImGui::Text("Fade if hidden");
+    ImGui::SameLine();
+    if(ImGui::Checkbox("##sphere.fadeIfHidden", &fadeIfHidden))
+    {
+        fadeHiddenParam.Update(fadeIfHidden);
     }
 
     ImGui::Spacing();

--- a/Engine/src/sh_field.cpp
+++ b/Engine/src/sh_field.cpp
@@ -52,31 +52,31 @@ void SHField::registerStateCallbacks()
     mState->VoxelGrid.SliceIndices.RegisterCallback(
         [this](glm::vec3 p, glm::vec3 n)
         {
-            this->SetSliceIndex(p, n);
+            this->setSliceIndex(p, n);
         }
     );
     mState->Sphere.IsNormalized.RegisterCallback(
         [this](bool p, bool n)
         {
-            this->SetNormalized(p, n);
+            this->setNormalized(p, n);
         }
     );
     mState->Sphere.SH0Threshold.RegisterCallback(
         [this](float p, float n)
         {
-            this->SetSH0Threshold(p, n);
+            this->setSH0Threshold(p, n);
         }
     );
     mState->Sphere.Scaling.RegisterCallback(
         [this](float p, float n)
         {
-            this->SetSphereScaling(p, n);
+            this->setSphereScaling(p, n);
         }
     );
     mState->Sphere.FadeIfHidden.RegisterCallback(
         [this](bool p, bool n)
         {
-            this->SetFadeIfHidden(p, n);
+            this->setFadeIfHidden(p, n);
         }
     );
 }
@@ -230,7 +230,7 @@ GLuint SHField::genVBO(const std::vector<T>& data) const
     return vbo;
 }
 
-void SHField::SetSliceIndex(glm::vec3 prevIndices, glm::vec3 newIndices)
+void SHField::setSliceIndex(glm::vec3 prevIndices, glm::vec3 newIndices)
 {
     glm::ivec4 isSliceDirty;
     isSliceDirty.x = prevIndices.x != newIndices.x;
@@ -246,7 +246,7 @@ void SHField::SetSliceIndex(glm::vec3 prevIndices, glm::vec3 newIndices)
     }
 }
 
-void SHField::SetNormalized(bool previous, bool isNormalized)
+void SHField::setNormalized(bool previous, bool isNormalized)
 {
     if(previous != isNormalized)
     {
@@ -259,7 +259,7 @@ void SHField::SetNormalized(bool previous, bool isNormalized)
 }
 
 
-void SHField::SetSH0Threshold(float previous, float threshold)
+void SHField::setSH0Threshold(float previous, float threshold)
 {
     if(previous != threshold)
     {
@@ -268,7 +268,7 @@ void SHField::SetSH0Threshold(float previous, float threshold)
 }
 
 
-void SHField::SetSphereScaling(float previous, float scaling)
+void SHField::setSphereScaling(float previous, float scaling)
 {
     if(previous != scaling)
     {
@@ -278,7 +278,7 @@ void SHField::SetSphereScaling(float previous, float scaling)
     }
 }
 
-void SHField::SetFadeIfHidden(bool previous, bool fadeEnabled)
+void SHField::setFadeIfHidden(bool previous, bool fadeEnabled)
 {
     if(previous != fadeEnabled)
     {

--- a/Engine/src/sh_field.cpp
+++ b/Engine/src/sh_field.cpp
@@ -272,7 +272,9 @@ void SHField::SetSphereScaling(float previous, float scaling)
 {
     if(previous != scaling)
     {
-        mSphereInfoData.Update(4*sizeof(unsigned int) + sizeof(float), sizeof(float), &scaling);
+        mSphereInfoData.Update(4*sizeof(unsigned int) + sizeof(float),
+                               sizeof(float),
+                               &scaling);
     }
 }
 
@@ -281,7 +283,9 @@ void SHField::SetFadeIfHidden(bool previous, bool fadeEnabled)
     if(previous != fadeEnabled)
     {
         unsigned int uintFadeEnabled = fadeEnabled ? 1 : 0;
-        mSphereInfoData.Update(5*sizeof(unsigned int) + 2*sizeof(float), sizeof(unsigned int), &uintFadeEnabled);
+        mSphereInfoData.Update(5*sizeof(unsigned int) + 2*sizeof(float),
+                               sizeof(unsigned int),
+                               &uintFadeEnabled);
     }
 }
 

--- a/Engine/src/sh_field.cpp
+++ b/Engine/src/sh_field.cpp
@@ -73,6 +73,12 @@ void SHField::registerStateCallbacks()
             this->SetSphereScaling(p, n);
         }
     );
+    mState->Sphere.FadeIfHidden.RegisterCallback(
+        [this](bool p, bool n)
+        {
+            this->SetFadeIfHidden(p, n);
+        }
+    );
 }
 
 void SHField::initProgramPipeline()
@@ -177,6 +183,7 @@ void SHField::initializeGPUData()
     sphereData.SH0threshold = mState->Sphere.SH0Threshold.Get();
     sphereData.Scaling = mState->Sphere.Scaling.Get();
     sphereData.NbCoeffs = mState->FODFImage.Get().dims().w;
+    sphereData.FadeIfHidden = mState->Sphere.FadeIfHidden.Get();
 
     GridData gridData;
     gridData.IsSliceDirty = glm::ivec4(1, 1, 1, 0);
@@ -266,6 +273,15 @@ void SHField::SetSphereScaling(float previous, float scaling)
     if(previous != scaling)
     {
         mSphereInfoData.Update(4*sizeof(unsigned int) + sizeof(float), sizeof(float), &scaling);
+    }
+}
+
+void SHField::SetFadeIfHidden(bool previous, bool fadeEnabled)
+{
+    if(previous != fadeEnabled)
+    {
+        unsigned int uintFadeEnabled = fadeEnabled ? 1 : 0;
+        mSphereInfoData.Update(5*sizeof(unsigned int) + 2*sizeof(float), sizeof(unsigned int), &uintFadeEnabled);
     }
 }
 


### PR DESCRIPTION
Better visibility.

Can be enabled/disabled in `Slice options` under `Fade if hidden`.

Enabled by default.