### PR TITLE
Accelerate SHField class initialization

### DIFF
--- a/Engine/include/application.h
+++ b/Engine/include/application.h
@@ -34,6 +34,9 @@ private:
     /// Initialize GLFW, OpenGL backend, Scene, UI, Camera, etc.
     void initialize();
 
+    /// Render a frame one time.
+    void renderFrame();
+
     /// Initialize the ApplicationState object.
     /// \param[in] parser The command line arguments.
     void initApplicationState(const ArgumentParser& parser);

--- a/Engine/include/scene.h
+++ b/Engine/include/scene.h
@@ -22,6 +22,9 @@ public:
     /// Destructor.
     ~Scene();
 
+    /// Add an SHField instance to the scene.
+    void AddSHField();
+
     /// Render the scene.
     void Render();
 

--- a/Engine/include/sh_field.h
+++ b/Engine/include/sh_field.h
@@ -142,7 +142,7 @@ private:
     /// \param[in] lastIndex Index (exclusive) of the last sphere to initialize.
     void initializeSubsetDrawCommand(size_t firstIndex, size_t lastIndex);
 
-    /// Dispatch some method for filling arrays in parrallel.
+    /// Dispatch some method for filling arrays in parallel.
     /// \param[in] fn Pointer to member function to call.
     /// \param[in] nbElements Number of elements to fill.
     /// \param[in] nbThreads Number of threads to use.

--- a/Engine/include/sh_field.h
+++ b/Engine/include/sh_field.h
@@ -3,6 +3,7 @@
 #include <glm/glm.hpp>
 #include <vector>
 #include <memory>
+#include <thread>
 #include <binding.h>
 #include <shader_data.h>
 #include <image.h>
@@ -130,11 +131,20 @@ private:
     /// Initialize data to be copied on the GPU.
     void initializeGPUData();
 
-    /// Fill SH coefficients array from image.
-    void copySHCoefficientsFromImage();
+    /// Copy a subset of the SH coefficients from the image
+    /// to contiguous array for GPU.
+    /// \param[in] firstIndex Index (flat) of the first coefficient to copy.
+    /// \param[in] lastIndex Index (exclusive) of the last coefficient to copy.
+    void copySubsetSHCoefficientsFromImage(size_t firstIndex, size_t lastIndex);
 
-    /// Initialize Draw command for instancing.
-    void initializeDrawCommand();
+    /// Initialize a subset of the Draw commands, used for instancing.
+    /// \param[in] firstIndex Index (flat) of the first sphere to initialize.
+    /// \param[in] lastIndex Index (exclusive) of the last sphere to initialize.
+    void initializeSubsetDrawCommand(size_t firstIndex, size_t lastIndex);
+
+    void dispatchSubsetCommand(void(SHField::*fn)(size_t, size_t),
+                               size_t nbElements, size_t nbThreads,
+                               std::vector<std::thread>& threads);
 
     /// Set sphere scaling.
     /// \param[in] previous Previous scaling multiplier.

--- a/Engine/include/sh_field.h
+++ b/Engine/include/sh_field.h
@@ -142,7 +142,12 @@ private:
     /// \param[in] lastIndex Index (exclusive) of the last sphere to initialize.
     void initializeSubsetDrawCommand(size_t firstIndex, size_t lastIndex);
 
-    void dispatchSubsetCommand(void(SHField::*fn)(size_t, size_t),
+    /// Dispatch some method for filling arrays in parrallel.
+    /// \param[in] fn Pointer to member function to call.
+    /// \param[in] nbElements Number of elements to fill.
+    /// \param[in] nbThreads Number of threads to use.
+    /// \param[out] threads Vector of threads.
+    void dispatchSubsetCommands(void(SHField::*fn)(size_t, size_t),
                                size_t nbElements, size_t nbThreads,
                                std::vector<std::thread>& threads);
 

--- a/Engine/include/sh_field.h
+++ b/Engine/include/sh_field.h
@@ -75,10 +75,10 @@ public:
     /// Destructor.
     ~SHField();
 
-    /// Scale spheres by launching a compute shader pass.
-    void ScaleSpheres();
-
 protected:
+    /// Scale spheres by launching a compute shader pass.
+    void scaleSpheres();
+
     /// \see Model::drawSpecific()
     void drawSpecific() override;
 

--- a/Engine/include/sphere.h
+++ b/Engine/include/sphere.h
@@ -33,15 +33,15 @@ public:
 
     /// Get indices array describing the sphere triangulation.
     /// \return Vector of indices.
-    inline std::vector<GLuint> getIndices() const { return mIndices; };
+    inline std::vector<GLuint> GetIndices() const { return mIndices; };
 
     /// Get the sphere points.
     /// \return Vector of points on the sphere.
-    inline std::vector<glm::vec4> getPoints() const { return mPoints; };
+    inline std::vector<glm::vec4> GetPoints() const { return mPoints; };
 
     /// Get the SH function at each sphere point.
     /// \return Vector of SH functions.
-    inline std::vector<float> getSHFuncs() const { return mSphHarmFunc; };
+    inline std::vector<float> GetSHFuncs() const { return mSphHarmFunc; };
 
     /// Get the maximum SH order.
     /// \return The maximum SH order for the basis.

--- a/Engine/src/application.cpp
+++ b/Engine/src/application.cpp
@@ -88,6 +88,7 @@ void Application::initialize()
     // Render frame without the model
     renderFrame();
 
+    // Add SH field once the UI is drawn
     mScene->AddSHField();
 }
 

--- a/Engine/src/application.cpp
+++ b/Engine/src/application.cpp
@@ -74,7 +74,6 @@ void Application::initialize()
     glfwSwapInterval(0);
 
     mUI.reset(new UIManager(mWindow, GLSL_VERSION_STR, mState));
-    mScene.reset(new Scene(mState));
 
     const float aspectRatio = (float)WIN_WIDTH/(float)WIN_HEIGHT;
     mCamera.reset(new Camera(glm::vec3(0.0f, 0.0f, 10.0f), // position
@@ -83,6 +82,13 @@ void Application::initialize()
                              glm::radians(60.0f), aspectRatio,
                              0.1f, 500.0f,
                              mState));
+
+    mScene.reset(new Scene(mState));
+
+    // Render frame without the model
+    renderFrame();
+
+    mScene->AddSHField();
 }
 
 void Application::initApplicationState(const ArgumentParser& parser)
@@ -105,23 +111,28 @@ void Application::initApplicationState(const ArgumentParser& parser)
     mState->Window.ZoomSpeed.Update(ZOOM_SPEED);
 }
 
+void Application::renderFrame()
+{
+    // Handle events
+    glfwPollEvents();
+
+    // Update camera parameters
+    mCamera->UpdateGPU();
+
+    // Draw scene
+    mScene->Render();
+
+    //Draw UI
+    mUI->DrawInterface();
+
+    glfwSwapBuffers(mWindow);
+}
+
 void Application::Run()
 {
     while (!glfwWindowShouldClose(mWindow))
     {
-        // Handle events
-        glfwPollEvents();
-
-        // Update camera parameters
-        mCamera->UpdateGPU();
-
-        // Draw scene
-        mScene->Render();
-
-        //Draw UI
-        mUI->DrawInterface();
-
-        glfwSwapBuffers(mWindow);
+        renderFrame();
     }
 }
 

--- a/Engine/src/model.cpp
+++ b/Engine/src/model.cpp
@@ -26,12 +26,13 @@ void Model::initializeModel()
 
 void Model::Draw()
 {
-    if(mIsInit)
+    if(!mIsInit)
     {
-        mProgramPipeline.Bind();
-        uploadTransformToGPU();
-        drawSpecific();
+        throw std::runtime_error("Model::Draw() called before initializeModel()");
     }
+    mProgramPipeline.Bind();
+    uploadTransformToGPU();
+    drawSpecific();
 }
 
 void Model::uploadTransformToGPU()

--- a/Engine/src/model.cpp
+++ b/Engine/src/model.cpp
@@ -26,15 +26,12 @@ void Model::initializeModel()
 
 void Model::Draw()
 {
-    if(!mIsInit)
+    if(mIsInit)
     {
-        std::string msg = "Model is not initialized.\n";
-        msg += "Initialize first by calling Model::initializeModel().";
-        throw std::runtime_error(msg);
+        mProgramPipeline.Bind();
+        uploadTransformToGPU();
+        drawSpecific();
     }
-    mProgramPipeline.Bind();
-    uploadTransformToGPU();
-    drawSpecific();
 }
 
 void Model::uploadTransformToGPU()

--- a/Engine/src/scene.cpp
+++ b/Engine/src/scene.cpp
@@ -10,12 +10,16 @@ Scene::Scene(const std::shared_ptr<ApplicationState>& state)
 :mState(state)
 ,mCoordinateSystem(new CoordinateSystem())
 {
-    // create a SH Field model
-    mModels.push_back(std::shared_ptr<SHField>(new SHField(mState, mCoordinateSystem)));
 }
 
 Scene::~Scene()
 {
+}
+
+void Scene::AddSHField()
+{
+    // create a SH Field model
+    mModels.push_back(std::shared_ptr<SHField>(new SHField(mState, mCoordinateSystem)));
 }
 
 void Scene::Render()

--- a/Engine/src/sh_field.cpp
+++ b/Engine/src/sh_field.cpp
@@ -111,11 +111,11 @@ void SHField::initializeMembers()
 
     // Copy SH coefficients to contiguous typed buffer.
     std::vector<std::thread> threads;
-    dispatchSubsetCommand(&SHField::copySubsetSHCoefficientsFromImage,
+    dispatchSubsetCommands(&SHField::copySubsetSHCoefficientsFromImage,
                           image.nbVox(), NB_THREADS_FOR_SH, threads);
 
     // Copy sphere indices and instantiate draw commands.
-    dispatchSubsetCommand(&SHField::initializeSubsetDrawCommand,
+    dispatchSubsetCommands(&SHField::initializeSubsetDrawCommand,
                           mNbSpheres, NB_THREADS_FOR_SPHERES, threads);
 
     // wait for all threads to finish
@@ -131,8 +131,8 @@ void SHField::initializeMembers()
     timer.Stop();
 }
 
-void SHField::dispatchSubsetCommand(void(SHField::*fn)(size_t, size_t), size_t nbElements,
-                                    size_t nbThreads, std::vector<std::thread>& threads)
+void SHField::dispatchSubsetCommands(void(SHField::*fn)(size_t, size_t), size_t nbElements,
+                                     size_t nbThreads, std::vector<std::thread>& threads)
 {
     size_t nbElementsPerThread = nbElements / nbThreads;
     size_t startIndex = 0;

--- a/Engine/src/sh_field.cpp
+++ b/Engine/src/sh_field.cpp
@@ -4,7 +4,7 @@
 
 namespace
 {
-const int NB_THREADS_FOR_SH = 6;
+const int NB_THREADS_FOR_SH = 4;
 const int NB_THREADS_FOR_SPHERES = 2;
 }
 

--- a/Engine/src/sh_field.cpp
+++ b/Engine/src/sh_field.cpp
@@ -36,7 +36,7 @@ SHField::SHField(const std::shared_ptr<ApplicationState>& state,
 
     initializeModel();
     initializeGPUData();
-    ScaleSpheres();
+    scaleSpheres();
 }
 
 SHField::~SHField()
@@ -242,7 +242,7 @@ void SHField::setSliceIndex(glm::vec3 prevIndices, glm::vec3 newIndices)
         glm::ivec4 sliceIndices = glm::ivec4(newIndices, 0);
         mGridInfoData.Update(sizeof(glm::ivec4), sizeof(glm::ivec4), &sliceIndices);
         mGridInfoData.Update(2*sizeof(glm::ivec4), sizeof(glm::ivec4), &isSliceDirty);
-        ScaleSpheres();
+        scaleSpheres();
     }
 }
 
@@ -254,7 +254,7 @@ void SHField::setNormalized(bool previous, bool isNormalized)
         glm::ivec4 isDirty(1, 1, 1, 0);
         mSphereInfoData.Update(sizeof(unsigned int)*2, sizeof(unsigned int), &isNormalizedInt);
         mGridInfoData.Update(2*sizeof(glm::ivec4), sizeof(glm::ivec4), &isDirty);
-        ScaleSpheres();
+        scaleSpheres();
     }
 }
 
@@ -298,7 +298,7 @@ void SHField::drawSpecific()
                                 (GLvoid*)0, mIndirectCmd.size(), 0);
 }
 
-void SHField::ScaleSpheres()
+void SHField::scaleSpheres()
 {
     glUseProgram(mComputeShader.ID());
     glDispatchCompute(mNbSpheres, 1, 1);


### PR DESCRIPTION
To make initializing the SH field look less like the program crashed, display the UI before initializing SH field. Also accelerate the initialization of SHField class to go faster than the "Window not responding" message.