### PR TITLE
Undo normals from gradients

### DIFF
--- a/Engine/include/binding.h
+++ b/Engine/include/binding.h
@@ -19,7 +19,6 @@ enum class Binding
     camera = 9,
     modelTransform = 10,
     allOrders = 11,
-    shFunctionsGrad = 12,
     none = 30
 };
 } // namespace GPU

--- a/Engine/include/sh_field.h
+++ b/Engine/include/sh_field.h
@@ -234,9 +234,6 @@ private:
     /// SH functions GPU data.
     GPU::ShaderData mSphHarmFuncsData;
 
-    /// Gradients of SH functions GPU data.
-    GPU::ShaderData mSphHarmFuncsGradData;
-
     /// Voxel grid GPU data.
     GPU::ShaderData mGridInfoData;
 

--- a/Engine/include/sphere.h
+++ b/Engine/include/sphere.h
@@ -43,10 +43,6 @@ public:
     /// \return Vector of SH functions.
     inline std::vector<float> GetSHFuncs() const { return mSphHarmFunc; };
 
-    /// Get the gradient of SH functions at each sphere point.
-    /// \return Vector of SH functions gradients.
-    inline std::vector<glm::vec4> GetSHFuncsGrad() const { return mSphHarmFuncGrad; };
-
     /// Get the maximum SH order.
     /// \return The maximum SH order for the basis.
     inline unsigned int GetMaxSHOrder() const {return mSHBasis->GetMaxOrder(); };
@@ -88,9 +84,6 @@ private:
 
     /// SH functions at each point in mPoints.
     std::vector<float> mSphHarmFunc;
-
-    /// Gradients of SH functions at each point in mPoints.
-    std::vector<glm::vec4> mSphHarmFuncGrad;
 
     /// SH basis in use.
     std::shared_ptr<SH::DescoteauxBasis> mSHBasis;

--- a/Engine/include/sphere.h
+++ b/Engine/include/sphere.h
@@ -60,7 +60,7 @@ private:
     void subdivide();
 
     /// Add a point to the sphere.
-    /// Also adds the SH functions and gradients evaluated for this point.
+    /// Also adds the SH functions for this point.
     /// \param[in] cartesian Point to add, expressed in cartesian coordinates
     void addPoint(const glm::vec3& cartesian);
 

--- a/Engine/src/sh_field.cpp
+++ b/Engine/src/sh_field.cpp
@@ -24,7 +24,6 @@ SHField::SHField(const std::shared_ptr<ApplicationState>& state,
 ,mIndirectBO(0)
 ,mSphHarmCoeffsData()
 ,mSphHarmFuncsData()
-,mSphHarmFuncsGradData()
 ,mSphereVerticesData()
 ,mSphereIndicesData()
 ,mSphereInfoData()
@@ -226,8 +225,6 @@ void SHField::initializeGPUData()
                                          sizeof(float) * mSphHarmCoeffs.size());
     mSphHarmFuncsData = GPU::ShaderData(mSphere->GetSHFuncs().data(), GPU::Binding::shFunctions,
                                         sizeof(float) * mSphere->GetSHFuncs().size());
-    mSphHarmFuncsGradData = GPU::ShaderData(mSphere->GetSHFuncsGrad().data(), GPU::Binding::shFunctionsGrad,
-                                            sizeof(glm::vec4) * mSphere->GetSHFuncsGrad().size());
     mAllOrdersData = GPU::ShaderData(allOrders.data(), GPU::Binding::allOrders,
                                      sizeof(float) * allOrders.size());
     mSphereVerticesData = GPU::ShaderData(mSphere->GetPoints().data(), GPU::Binding::sphereVertices,
@@ -242,7 +239,6 @@ void SHField::initializeGPUData()
     // push all data to GPU
     mSphHarmCoeffsData.ToGPU();
     mSphHarmFuncsData.ToGPU();
-    mSphHarmFuncsGradData.ToGPU();
     mAllOrdersData.ToGPU();
     mSphereVerticesData.ToGPU();
     mSphereIndicesData.ToGPU();


### PR DESCRIPTION
Because the gradient method did not result in a big gain in speed and introduced visual bugs, we roll back to triangle-based normal computation. 

Closes #17 