### PR TITLE
Hide slices in 2D mode

### DIFF
--- a/Engine/include/sh_field.h
+++ b/Engine/include/sh_field.h
@@ -116,6 +116,7 @@ private:
     {
         glm::ivec4 VolumeShape;
         glm::ivec4 SliceIndices;
+        glm::ivec4 IsVisible;
         uint CurrentSlice;
     };
 
@@ -172,6 +173,11 @@ private:
     /// \param[in] previous Previous value.
     /// \param[in] fadeEnabled New value for fading behaviour.
     void setFadeIfHidden(bool previous, bool fadeEnabled);
+
+    /// Set slices to visible or invisible.
+    /// \param[in] previous Previous view mode.
+    /// \param[in] fadeEnabled New view mode.
+    void setVisibleSlices(State::CameraMode previous, State::CameraMode next);
 
     /// Generate a vertex buffer object for data.
     /// \param[in] data The data to send to the GPU.

--- a/Engine/shaders/shfield_comp.glsl
+++ b/Engine/shaders/shfield_comp.glsl
@@ -46,6 +46,7 @@ layout(std430, binding=8) buffer gridInfoBuffer
 {
     ivec4 gridDims;
     ivec4 sliceIndex;
+    ivec4 isSliceVisible;
     uint currentSlice;
 };
 

--- a/Engine/shaders/shfield_frag.glsl
+++ b/Engine/shaders/shfield_frag.glsl
@@ -9,19 +9,8 @@ layout(std430, binding=8) buffer gridInfoBuffer
 {
     ivec4 gridDims;
     ivec4 sliceIndex;
+    ivec4 isSliceVisible;
     uint currentSlice;
-};
-
-layout(std430, binding=7) buffer sphereInfoBuffer
-{
-    uint nbVertices;
-    uint nbIndices;
-    uint isNormalized; // bool
-    uint maxOrder;
-    float sh0Threshold;
-    float scaling;
-    uint nbCoeffs;
-    uint fadeIfHidden; // bool
 };
 
 in vec4 world_frag_pos;
@@ -30,6 +19,7 @@ in vec4 world_normal;
 in vec4 world_eye_pos;
 in vec4 vertex_slice;
 in float is_visible;
+in float fade_enabled;
 
 out vec4 shaded_color;
 
@@ -155,6 +145,6 @@ void main()
     vec3 ambient = color.xyz * KA;
     vec3 specular = vec3(1.0f) * dot(r, frag_to_eye) * KS;
 
-    vec3 outColor = (ambient + diffuse + specular) * (fadeIfHidden > 0 ? GetFading() : 1.0f);
+    vec3 outColor = (ambient + diffuse + specular) * (fade_enabled > 0 ? GetFading() : 1.0f);
     shaded_color = vec4(outColor, 1.0f);
 }


### PR DESCRIPTION
Remove the slices that are not focused when in 2D mode. Does what PR #26 does but uses a different approach.

@julienbernat you can have a look on how this can be done directly in shaders. Understanding how the code works will most likely help you with your background texture task! If you or Achille could review that'd be appreciated, but there is no hurry to merge this one.

I need to uniformize the coding standards across shader code. I'll probably do so in a future PR though.
Thanks!