### PR TITLE
Add support for shader #include directives

### DIFF
--- a/Engine/include/shader.h
+++ b/Engine/include/shader.h
@@ -30,10 +30,10 @@ public:
     /// \return Shader type.
     inline const GLenum Type() const { return mShaderType; };
 
-private:
     /// Create the virtual filesystem for include directives.
-    static void createFilesystemForInclude();
+    static void CreateFilesystemForInclude();
 
+private:
     /// Static array of shader include paths (shared across all instances).
     inline static std::vector<const char*> mShaderIncludePaths = {};
 

--- a/Engine/include/shader.h
+++ b/Engine/include/shader.h
@@ -22,14 +22,6 @@ public:
     /// \param[in] shaderType Type for the shader.
     ShaderProgram(const std::string& filepath, const GLenum shaderType);
 
-    /// Constructor.
-    /// \param[in] filePath Path to shader code.
-    /// \param[in] includePaths Paths to include shader code.
-    /// \param[in] shaderType Type for the shader.
-    ShaderProgram(const std::string& filePath,
-                  std::vector<std::string>& includePaths,
-                  const GLenum shaderType);
-
     /// Shader program ID getter.
     /// \return Program ID.
     inline const GLuint ID() const { return mProgramID; };
@@ -39,6 +31,15 @@ public:
     inline const GLenum Type() const { return mShaderType; };
 
 private:
+    /// Create the virtual filesystem for include directives.
+    static void createFilesystemForInclude();
+
+    /// Static array of shader include paths (shared across all instances).
+    inline static std::vector<const char*> mShaderIncludePaths = {};
+
+    /// Static array of shader include path lengths (shared across all instances).
+    inline static std::vector<int> mShaderIncludeLengths = {};
+
     /// Program ID.
     GLuint mProgramID = 0;
 

--- a/Engine/include/shader.h
+++ b/Engine/include/shader.h
@@ -22,6 +22,14 @@ public:
     /// \param[in] shaderType Type for the shader.
     ShaderProgram(const std::string& filepath, const GLenum shaderType);
 
+    /// Constructor.
+    /// \param[in] filePath Path to shader code.
+    /// \param[in] includePaths Paths to include shader code.
+    /// \param[in] shaderType Type for the shader.
+    ShaderProgram(const std::string& filePath,
+                  std::vector<std::string>& includePaths,
+                  const GLenum shaderType);
+
     /// Shader program ID getter.
     /// \return Program ID.
     inline const GLuint ID() const { return mProgramID; };

--- a/Engine/shaders/include/camera_util.glsl
+++ b/Engine/shaders/include/camera_util.glsl
@@ -2,9 +2,16 @@
 Camera parameters.
 */
 
+/// Camera parameters buffer.
 layout(std430, binding=9) buffer cameraBuffer
 {
+    /// Eye position in world coordinates.
     vec4 eye;
+
+    /// View matrix tranforming world coordinates
+    /// to camera coordinates.
     mat4 viewMatrix;
+
+    /// Projection matrix.
     mat4 projectionMatrix;
 };

--- a/Engine/shaders/include/camera_util.glsl
+++ b/Engine/shaders/include/camera_util.glsl
@@ -1,0 +1,10 @@
+/*
+Camera parameters.
+*/
+
+layout(std430, binding=9) buffer cameraBuffer
+{
+    vec4 eye;
+    mat4 viewMatrix;
+    mat4 projectionMatrix;
+};

--- a/Engine/shaders/include/orthogrid_util.glsl
+++ b/Engine/shaders/include/orthogrid_util.glsl
@@ -1,0 +1,67 @@
+/*
+Utilities and buffer objects for managing the voxel grid.
+*/
+
+layout(std430, binding=8) buffer gridInfoBuffer
+{
+    ivec4 gridDims;
+    ivec4 sliceIndex;
+    ivec4 isSliceVisible;
+    uint currentSlice; // 0, 1 or 2 for glyph deformation (compute shader)
+};
+
+uint convertSHCoeffsIndex3DToFlatVoxID(uint i, uint j, uint k)
+{
+    return k * gridDims.x * gridDims.y + j * gridDims.x + i;
+}
+
+bool belongsToXSlice(uint flatOrthoSlicesID)
+{
+    return flatOrthoSlicesID >= gridDims.x * gridDims.y &&
+           flatOrthoSlicesID < gridDims.x * gridDims.y + gridDims.y * gridDims.z;
+}
+
+bool belongsToZSlice(uint flatOrthoSlicesID)
+{
+    return flatOrthoSlicesID < gridDims.x * gridDims.y;
+}
+
+ivec3 convertFlatOrthoSlicesIDTo3DVoxID(uint flatOrthoSlicesID)
+{
+    if(belongsToZSlice(flatOrthoSlicesID))
+    {
+        // XY-slice
+        const uint j = flatOrthoSlicesID / gridDims.x;
+        const uint i = flatOrthoSlicesID - j * gridDims.x;
+        return ivec3(i, j, sliceIndex.z);
+    }
+    if(belongsToXSlice(flatOrthoSlicesID))
+    {
+        // YZ-slice
+        const uint j = (flatOrthoSlicesID - gridDims.x * gridDims.y) /gridDims.z;
+        const uint k = flatOrthoSlicesID - gridDims.x * gridDims.y - j * gridDims.z;
+        return ivec3(sliceIndex.x, j, k);
+    }
+    // XZ-slice
+    const uint k = (flatOrthoSlicesID - gridDims.x * gridDims.y - gridDims.y * gridDims.z) / gridDims.x;
+    const uint i = flatOrthoSlicesID - gridDims.x * gridDims.y - gridDims.y * gridDims.z - k * gridDims.x;
+    return ivec3(i, sliceIndex.y, k);
+}
+
+bool is3DMode()
+{
+    return isSliceVisible.x !=0 && isSliceVisible.y != 0 && isSliceVisible.z != 0;
+}
+
+bool getIsFlatOrthoSlicesIDVisible(const uint flatOrthoSlicesID)
+{
+    if(belongsToXSlice(flatOrthoSlicesID))
+    {
+        return isSliceVisible.x != 0;
+    }
+    if(belongsToZSlice(flatOrthoSlicesID))
+    {
+        return isSliceVisible.z != 0;
+    }
+    return isSliceVisible.y != 0;
+}

--- a/Engine/shaders/include/orthogrid_util.glsl
+++ b/Engine/shaders/include/orthogrid_util.glsl
@@ -2,30 +2,61 @@
 Utilities and buffer objects for managing the voxel grid.
 */
 
+/// Grid parameters buffer.
 layout(std430, binding=8) buffer gridInfoBuffer
 {
+    /// Dimensions of the voxel grid.
+    /// 3-dimensional; 4th dimension is undefined.
     ivec4 gridDims;
+
+    /// Index of slice of interest along each dimension.
+    /// 3-dimensional; 4th dimension is undefined.
     ivec4 sliceIndex;
+
+    /// Flag for slice visibility along each dimension. 0 means not visible;
+    /// 1 means visible. Used for hiding slices in 2D mode.
     ivec4 isSliceVisible;
-    uint currentSlice; // 0, 1 or 2 for glyph deformation (compute shader)
+
+    /// Current slice to be processed for glyph deformation. Only used during
+    /// compute shader pass for scaling spheres. Can take the values 0, 1, 2.
+    uint currentSlice;
 };
 
+/// Convert 3D grid index to flat index for accessing SH coeffs array.
 uint convertSHCoeffsIndex3DToFlatVoxID(uint i, uint j, uint k)
 {
     return k * gridDims.x * gridDims.y + j * gridDims.x + i;
 }
 
+/// Get whether the current index inside the 3 slices of interest
+/// belongs to the X slice.
+///
+/// Note: The flatOrthSlicesID goes from 0 to gridDims.x*gridDims.y+
+/// gridDims.y*gridDims.z+gridDims.z*gridDims.x and covers all the
+/// voxels belonging to the slices of interest.
 bool belongsToXSlice(uint flatOrthoSlicesID)
 {
     return flatOrthoSlicesID >= gridDims.x * gridDims.y &&
            flatOrthoSlicesID < gridDims.x * gridDims.y + gridDims.y * gridDims.z;
 }
 
+/// Get whether the current index inside the 3 slices of interest
+/// belongs to the Z slice.
+///
+/// Note: The flatOrthSlicesID goes from 0 to gridDims.x*gridDims.y+
+/// gridDims.y*gridDims.z+gridDims.z*gridDims.x and covers all the
+/// voxels belonging to the slices of interest.
 bool belongsToZSlice(uint flatOrthoSlicesID)
 {
     return flatOrthoSlicesID < gridDims.x * gridDims.y;
 }
 
+/// Convert a flatOrtoSlicesID to its corresponding voxel position
+/// on the grid.
+///
+/// Note: The flatOrthSlicesID goes from 0 to gridDims.x*gridDims.y+
+/// gridDims.y*gridDims.z+gridDims.z*gridDims.x and covers all the
+/// voxels belonging to the slices of interest.
 ivec3 convertFlatOrthoSlicesIDTo3DVoxID(uint flatOrthoSlicesID)
 {
     if(belongsToZSlice(flatOrthoSlicesID))
@@ -48,11 +79,20 @@ ivec3 convertFlatOrthoSlicesIDTo3DVoxID(uint flatOrthoSlicesID)
     return ivec3(i, sliceIndex.y, k);
 }
 
+/// Get whether the view mode is 3D or not. The view mode is
+/// 3D when all slices are visible.
 bool is3DMode()
 {
     return isSliceVisible.x !=0 && isSliceVisible.y != 0 && isSliceVisible.z != 0;
 }
 
+/// Determine if the voxel at position flatOrthoSlicesID is visible
+/// by querying its isSliceVisible value, depending on the slice it
+/// belongs to.
+///
+/// Note: The flatOrthSlicesID goes from 0 to gridDims.x*gridDims.y+
+/// gridDims.y*gridDims.z+gridDims.z*gridDims.x and covers all the
+/// voxels belonging to the slices of interest.
 bool getIsFlatOrthoSlicesIDVisible(const uint flatOrthoSlicesID)
 {
     if(belongsToXSlice(flatOrthoSlicesID))

--- a/Engine/shaders/include/shfield_util.glsl
+++ b/Engine/shaders/include/shfield_util.glsl
@@ -1,0 +1,40 @@
+/*
+Global variables for sphere topology.
+*/
+
+layout(std430, binding=3) buffer shCoeffsBuffer
+{
+    float shCoeffs[];
+};
+
+layout(std430, binding=4) buffer shFunctionsBuffer
+{
+    float shFuncs[];
+};
+
+layout(std430, binding=11) buffer ordersBuffer
+{
+    float L[];
+};
+
+layout(std430, binding=5) buffer sphereVerticesBuffer
+{
+    vec4 vertices[];
+};
+
+layout(std430, binding=6) buffer sphereIndicesBuffer
+{
+    uint indices[];
+};
+
+layout(std430, binding=7) buffer sphereInfoBuffer
+{
+    uint nbVertices;
+    uint nbIndices;
+    uint isNormalized; // bool
+    uint maxOrder;
+    float sh0Threshold;
+    float scaling;
+    uint nbCoeffs;
+    uint fadeIfHidden; // bool
+};

--- a/Engine/shaders/include/shfield_util.glsl
+++ b/Engine/shaders/include/shfield_util.glsl
@@ -1,40 +1,69 @@
 /*
-Global variables for sphere topology.
+Global variables for spherical harmonics (SH) field parameters.
 */
 
+/// SH coefficients image buffer.
 layout(std430, binding=3) buffer shCoeffsBuffer
 {
+    /// Flattened array of SH coefficients for a whole image.
     float shCoeffs[];
 };
 
+/// SH functions buffer.
 layout(std430, binding=4) buffer shFunctionsBuffer
 {
+    /// Table of all SH functions evaluated for each sphere
+    /// direction on the sphere to use for rendering.
     float shFuncs[];
 };
 
+/// SH orders buffer.
 layout(std430, binding=11) buffer ordersBuffer
 {
+    /// Array of length equal to the number of SH coefficients containing the
+    /// integer order for each SH coefficient.
     float L[];
 };
 
+/// Sphere vertices buffer.
 layout(std430, binding=5) buffer sphereVerticesBuffer
 {
+    /// Vertices defining the sphere used for glyphs visualization.
     vec4 vertices[];
 };
 
+/// Sphere indices buffer.
 layout(std430, binding=6) buffer sphereIndicesBuffer
 {
+    /// Vertex indices defining the sphere triangulation.
     uint indices[];
 };
 
+/// Sphere parameters buffer.
 layout(std430, binding=7) buffer sphereInfoBuffer
 {
+    /// Number of vertices.
     uint nbVertices;
+
+    /// Number of indices (3 x number of triangles).
     uint nbIndices;
-    uint isNormalized; // bool
+
+    /// Is the sphere normalized (L-max norm)? 1 or 0.
+    uint isNormalized;
+
+    /// The maximum SH order for the truncated SH series.
     uint maxOrder;
+
+    /// Threshold on 0th SH coefficient. Voxels below the
+    /// threshold may be discarded.
     float sh0Threshold;
+
+    /// The scaling factor for SH glyphs.
     float scaling;
+
+    /// Number of SH coefficients.
     uint nbCoeffs;
-    uint fadeIfHidden; // bool
+
+    /// 1 or 0. Flag for fading out glyphs that are below another slice.
+    uint fadeIfHidden;
 };

--- a/Engine/shaders/shfield_comp.glsl
+++ b/Engine/shaders/shfield_comp.glsl
@@ -1,4 +1,9 @@
 #version 460
+#extension GL_ARB_shading_language_include : require
+
+#include "/include/shfield_util.glsl"
+#include "/include/orthogrid_util.glsl"
+
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
 layout(std430, binding=0) buffer allRadiisBuffer
@@ -9,50 +14,6 @@ layout(std430, binding=0) buffer allRadiisBuffer
 layout(std430, binding=1) buffer allSpheresNormalsBuffer
 {
     vec4 allNormals[];
-};
-
-layout(std430, binding=3) buffer shCoeffsBuffer
-{
-    float shCoeffs[];
-};
-
-layout(std430, binding=4) buffer shFunctionsBuffer
-{
-    float shFuncs[];
-};
-
-layout(std430, binding=5) buffer sphereVerticesBuffer
-{
-    vec4 vertices[];
-};
-
-layout(std430, binding=6) buffer sphereIndicesBuffer
-{
-    uint indices[];
-};
-
-layout(std430, binding=7) buffer sphereInfoBuffer
-{
-    uint nbVertices;
-    uint nbIndices;
-    uint isNormalized; // bool
-    uint maxOrder;
-    float sh0Threshold;
-    float scaling;
-    uint nbCoeffs;
-};
-
-layout(std430, binding=8) buffer gridInfoBuffer
-{
-    ivec4 gridDims;
-    ivec4 sliceIndex;
-    ivec4 isSliceVisible;
-    uint currentSlice;
-};
-
-layout(std430, binding=11) buffer ordersBuffer
-{
-    float L[];
 };
 
 const float FLOAT_EPS = 1e-4;
@@ -129,11 +90,6 @@ void updateNormals(uint firstNormalID)
     }
 }
 
-uint convertIndex3DToVoxID(uint i, uint j, uint k)
-{
-    return k * gridDims.x * gridDims.y + j * gridDims.x + i;
-}
-
 void main()
 {
     uint i, j, k, outSphereID;
@@ -159,7 +115,7 @@ void main()
         i = gl_GlobalInvocationID.x - j * gridDims.x;
     }
 
-    const uint voxID = convertIndex3DToVoxID(i, j, k);
+    const uint voxID = convertSHCoeffsIndex3DToFlatVoxID(i, j, k);
     const uint firstVertID = outSphereID * nbVertices;
     if(scaleSphere(voxID, firstVertID))
     {

--- a/Engine/shaders/shfield_frag.glsl
+++ b/Engine/shaders/shfield_frag.glsl
@@ -1,16 +1,11 @@
 #version 460
+#extension GL_ARB_shading_language_include : require
+
+#include "/include/orthogrid_util.glsl"
 
 layout(std430, binding=10) buffer modelTransformsBuffer
 {
     mat4 modelMatrix;
-};
-
-layout(std430, binding=8) buffer gridInfoBuffer
-{
-    ivec4 gridDims;
-    ivec4 sliceIndex;
-    ivec4 isSliceVisible;
-    uint currentSlice;
 };
 
 in vec4 world_frag_pos;

--- a/Engine/src/application.cpp
+++ b/Engine/src/application.cpp
@@ -2,6 +2,7 @@
 #include <iostream>
 #include <application_state.h>
 #include <image.h>
+#include <shader.h>
 
 namespace
 {
@@ -88,6 +89,10 @@ void Application::initialize()
                              glm::radians(60.0f), aspectRatio,
                              0.1f, 500.0f,
                              mState));
+
+    // Create the virtual filesystem for shader include directives.
+    // Must be done before any ShaderProgram is instantiated.
+    GPU::ShaderProgram::CreateFilesystemForInclude();
 
     mScene.reset(new Scene(mState));
 

--- a/Engine/src/sh_field.cpp
+++ b/Engine/src/sh_field.cpp
@@ -91,9 +91,19 @@ void SHField::initProgramPipeline()
 {
     const std::string vsPath = DMRI_EXPLORER_BINARY_DIR + std::string("/shaders/shfield_vert.glsl");
     const std::string fsPath = DMRI_EXPLORER_BINARY_DIR + std::string("/shaders/shfield_frag.glsl");
+
+    std::vector<std::string> vsIncludes = {
+        "/include/camera_util.glsl",
+        "/include/shfield_util.glsl",
+        "/include/orthogrid_util.glsl"};
+    
+    std::vector<std::string> fsIncludes = {
+        "/include/orthogrid_util.glsl"
+    };
+
     std::vector<GPU::ShaderProgram> shaders;
-    shaders.push_back(GPU::ShaderProgram(vsPath, GL_VERTEX_SHADER));
-    shaders.push_back(GPU::ShaderProgram(fsPath, GL_FRAGMENT_SHADER));
+    shaders.push_back(GPU::ShaderProgram(vsPath, vsIncludes, GL_VERTEX_SHADER));
+    shaders.push_back(GPU::ShaderProgram(fsPath, fsIncludes, GL_FRAGMENT_SHADER));
     mProgramPipeline = GPU::ProgramPipeline(shaders);
 }
 
@@ -103,7 +113,10 @@ void SHField::initializeMembers()
     timer.Start();
     // Initialize compute shader
     const std::string csPath = DMRI_EXPLORER_BINARY_DIR + std::string("/shaders/shfield_comp.glsl");
-    mComputeShader = GPU::ShaderProgram(csPath, GL_COMPUTE_SHADER);
+    std::vector<std::string> includes = {
+        "/include/shfield_util.glsl",
+        "/include/orthogrid_util.glsl"};
+    mComputeShader = GPU::ShaderProgram(csPath, includes, GL_COMPUTE_SHADER);
 
     // Initialize a sphere for SH to SF projection
     const auto& image = mState->FODFImage.Get();

--- a/Engine/src/sh_field.cpp
+++ b/Engine/src/sh_field.cpp
@@ -92,18 +92,9 @@ void SHField::initProgramPipeline()
     const std::string vsPath = DMRI_EXPLORER_BINARY_DIR + std::string("/shaders/shfield_vert.glsl");
     const std::string fsPath = DMRI_EXPLORER_BINARY_DIR + std::string("/shaders/shfield_frag.glsl");
 
-    std::vector<std::string> vsIncludes = {
-        "/include/camera_util.glsl",
-        "/include/shfield_util.glsl",
-        "/include/orthogrid_util.glsl"};
-    
-    std::vector<std::string> fsIncludes = {
-        "/include/orthogrid_util.glsl"
-    };
-
     std::vector<GPU::ShaderProgram> shaders;
-    shaders.push_back(GPU::ShaderProgram(vsPath, vsIncludes, GL_VERTEX_SHADER));
-    shaders.push_back(GPU::ShaderProgram(fsPath, fsIncludes, GL_FRAGMENT_SHADER));
+    shaders.push_back(GPU::ShaderProgram(vsPath, GL_VERTEX_SHADER));
+    shaders.push_back(GPU::ShaderProgram(fsPath, GL_FRAGMENT_SHADER));
     mProgramPipeline = GPU::ProgramPipeline(shaders);
 }
 
@@ -113,10 +104,7 @@ void SHField::initializeMembers()
     timer.Start();
     // Initialize compute shader
     const std::string csPath = DMRI_EXPLORER_BINARY_DIR + std::string("/shaders/shfield_comp.glsl");
-    std::vector<std::string> includes = {
-        "/include/shfield_util.glsl",
-        "/include/orthogrid_util.glsl"};
-    mComputeShader = GPU::ShaderProgram(csPath, includes, GL_COMPUTE_SHADER);
+    mComputeShader = GPU::ShaderProgram(csPath, GL_COMPUTE_SHADER);
 
     // Initialize a sphere for SH to SF projection
     const auto& image = mState->FODFImage.Get();

--- a/Engine/src/shader.cpp
+++ b/Engine/src/shader.cpp
@@ -22,8 +22,6 @@ ShaderProgram::ShaderProgram(const std::string& filePath,
                              const GLenum shaderType)
 :mShaderType(shaderType)
 {
-    createFilesystemForInclude();
-
     const std::string strShader = readFile(filePath);
     GLint lenShader[1] = { static_cast<GLint>(strShader.length()) };
     const GLchar* strShaderC_str = strShader.c_str();
@@ -43,14 +41,8 @@ ShaderProgram::ShaderProgram(const std::string& filePath,
     assertProgramLinkingSuccess(this->mProgramID);
 }
 
-void ShaderProgram::createFilesystemForInclude()
+void ShaderProgram::CreateFilesystemForInclude()
 {
-    if(!mShaderIncludePaths.empty())
-    {
-        // Static arrays must be filled only once.
-        return;
-    }
-
     for(int i = 0; i < NUM_SHADER_INCLUDES; ++i)
     {
         const auto pathName = SHADER_INCLUDE_PATHS[i];

--- a/Engine/src/shader.cpp
+++ b/Engine/src/shader.cpp
@@ -1,11 +1,13 @@
 #include "shader.h"
 #include "utils.hpp"
+#include <algorithm>
 
 namespace Slicer
 {
 namespace GPU
 {
 ShaderProgram::ShaderProgram(const std::string& filePath, const GLenum shaderType)
+:mShaderType(shaderType)
 {
     std::string strShader = readFile(filePath);
     GLint lenShader[1] = { static_cast<GLint>(strShader.length()) };
@@ -14,15 +16,55 @@ ShaderProgram::ShaderProgram(const std::string& filePath, const GLenum shaderTyp
     GLuint shaderID = glCreateShader(shaderType);
 
     glShaderSource(shaderID, 1, &strShaderC_str, lenShader);
-    glCompileShader(shaderID);
-
+    
+    glCompileShaderIncludeARB(shaderID, 0, nullptr, nullptr);
     assertShaderCompilationSuccess(shaderID, filePath);
+
     this->mProgramID = glCreateProgram();
     glProgramParameteri(this->mProgramID, GL_PROGRAM_SEPARABLE, GL_TRUE);
     glAttachShader(this->mProgramID, shaderID);
     glLinkProgram(this->mProgramID);
     assertProgramLinkingSuccess(this->mProgramID);
-    this->mShaderType = shaderType;
+}
+
+ShaderProgram::ShaderProgram(const std::string& filePath,
+                             std::vector<std::string>& includePaths,
+                             const GLenum shaderType)
+:mShaderType(shaderType)
+{
+    std::sort(includePaths.begin(), includePaths.end());
+    std::vector<const char*> includePathsRaw;
+    std::vector<int> includeLengths;
+    for(const std::string& pathName : includePaths)
+    {
+        const std::string strInclude = readFile(
+            DMRI_EXPLORER_BINARY_DIR + std::string("/shaders") + pathName);
+
+        // Add to virtual filesystem.
+        glNamedStringARB(GL_SHADER_INCLUDE_ARB, pathName.length(),
+                         pathName.c_str(), strInclude.length(),
+                         strInclude.c_str());
+        
+        includePathsRaw.push_back(pathName.c_str());
+        includeLengths.push_back(static_cast<int>(pathName.length()));
+    }
+
+    const std::string strShader = readFile(filePath);
+    GLint lenShader[1] = { static_cast<GLint>(strShader.length()) };
+    const GLchar* strShaderC_str = strShader.c_str();
+
+    GLuint shaderID = glCreateShader(shaderType);
+    glShaderSource(shaderID, 1, &strShaderC_str, lenShader);
+    glCompileShaderIncludeARB(shaderID, includePathsRaw.size(),
+                              includePathsRaw.data(),
+                              includeLengths.data());
+    assertShaderCompilationSuccess(shaderID, filePath);
+
+    this->mProgramID = glCreateProgram();
+    glProgramParameteri(this->mProgramID, GL_PROGRAM_SEPARABLE, GL_TRUE);
+    glAttachShader(this->mProgramID, shaderID);
+    glLinkProgram(this->mProgramID);
+    assertProgramLinkingSuccess(this->mProgramID);
 }
 
 ProgramPipeline::ProgramPipeline(const std::vector<ShaderProgram>& shaderPrograms)

--- a/contributing.md
+++ b/contributing.md
@@ -50,6 +50,8 @@ OpenGL shaders are written in the OpenGL shading language (`glsl`) version 4.60.
 
 If you use a different shader type, please propose a suffix following this convention.
 
+Shader `#include` directives are supported. Utilities files should be located under the `Engine/shaders/include/` directory and end with `_util.glsl`.
+
 __Variable name style__
 
 In shader code, we distinguish between variables shared between shaders (`in` and `out` keywords) and local variables by using a different style:


### PR DESCRIPTION
Create virtual filesystem on the GPU for supporting `#include` directives from shader code.

**TODO**
* [x] Document utility functions in `*_util.glsl` shader code.
* [x] Update `contributing.md`.

@julienbernat @Troy-boy
I think this is a game changer for writing shader code. No more code duplicates!
Please have a look! :)

Closes #3 
